### PR TITLE
Changed parameter version for VersionTagRelease

### DIFF
--- a/CODIGO/frmCargando.frm
+++ b/CODIGO/frmCargando.frm
@@ -139,7 +139,7 @@ Private Function CheckIfRunningLastVersion() As Boolean
     Set JsonObject = JSON.parse(responseGithub)
     
     versionNumberMaster = JsonObject.Item("tag_name")
-    versionNumberLocal = GetVar(App.path & "\INIT\Config.ini", "Cliente", "version")
+    versionNumberLocal = GetVar(App.path & "\INIT\Config.ini", "Cliente", "VersionTagRelease")
     
     If versionNumberMaster = versionNumberLocal Then
         CheckIfRunningLastVersion = True

--- a/INIT/Config.ini
+++ b/INIT/Config.ini
@@ -2,4 +2,4 @@
 fileToOpen=\Autoupdate.exe
 
 [Cliente]
-version=12
+VersionTagRelease=v13.3.1


### PR DESCRIPTION
Changed parameter version for VersionTagRelease to maintain name normalization with the ao-server repository