### PR TITLE
Agregar chqeueos necesarios faltantes en el frmCrearPersonaje

### DIFF
--- a/CODIGO/frmCrearPersonaje.frm
+++ b/CODIGO/frmCrearPersonaje.frm
@@ -1477,6 +1477,25 @@ Private Sub CargarCombos()
 End Sub
 
 Function CheckData() As Boolean
+    
+    If LenB(txtNombre.Text) = 0 Then
+        MsgBox "Ingresa el nombre de tu nuevo personaje."
+        txtNombre.SetFocus
+        Exit Function
+    End If
+    
+    If LenB(txtPasswd.Text) = 0 Then
+        MsgBox "Ingresa una contraseña."
+        txtPasswd.SetFocus
+        Exit Function
+    End If
+    
+    If LenB(txtConfirmPasswd.Text) = 0 Then
+        MsgBox "Debes ingresar nuevamente la contraseña."
+        txtConfirmPasswd.SetFocus
+        Exit Function
+    End If
+    
     If txtPasswd.Text <> txtConfirmPasswd.Text Then
         MsgBox "Los passwords que tipeo no coinciden, por favor vuelva a ingresarlos."
         Exit Function


### PR DESCRIPTION
Parece que se podía crear un personaje dejando el campo "contraseña" y "confirmar contraseña" vacíos.
El chequeo del nickname (txtNombre) no puede faltar tampoco.