### PR TITLE
Temporally fixed D3D memory corruption.

### DIFF
--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -34,7 +34,7 @@ Attribute VB_Name = "Mod_General"
 Option Explicit
 
 #If False Then 'to fix VB fucking up the var names
-    Dim Status, Nombre, PicInv, f, Obj, J As String
+    Dim status, Nombre, PicInv, f, obj, j As String
 #End If
 
 Public iplst As String
@@ -491,7 +491,7 @@ Sub SwitchMap(ByVal Map As Integer)
     Dim ByFlags As Byte
     Dim handle As Integer
     Dim CharIndex As Integer
-    Dim Obj       As Integer
+    Dim obj       As Integer
     
     handle = FreeFile()
     
@@ -557,9 +557,9 @@ Sub SwitchMap(ByVal Map As Integer)
             End If
 
             'Erase OBJs
-            Obj = Map_PosExitsObject(X, Y)
+            obj = Map_PosExitsObject(X, Y)
 
-            If (Obj > 0) Then
+            If (obj > 0) Then
                 Call Map_DestroyObject(X, Y)
             End If
             
@@ -806,9 +806,7 @@ Sub Main()
     Call Load(frmScreenshots)
         
     Do While prgRun
-    
-        Engine_BeginScene
-        
+
         'Solo dibujamos si la ventana no esta minimizada
         If frmMain.WindowState <> 1 And frmMain.Visible Then
             Call ShowNextFrame(frmMain.Top, frmMain.Left, frmMain.MouseX, frmMain.MouseY)
@@ -828,9 +826,8 @@ Sub Main()
         ' If there is anything to be sent, we send it
         Call FlushBuffer
         
-        DoEvents 'DoEvents must be within BeginScene() and EndScene() to allow drawing from any UI's event (Except Modal)
+        DoEvents
         
-        Engine_EndScene
     Loop
     
     Call CloseClient
@@ -852,14 +849,14 @@ Private Sub LoadInitialConfig()
     
     '###########
     ' SERVIDORES
-    Call AddtoRichTextBox(frmCargando.Status, "Buscando servidores... ", 255, 255, 255, True, False, True)
+    Call AddtoRichTextBox(frmCargando.status, "Buscando servidores... ", 255, 255, 255, True, False, True)
     Call DownloadServersFile("https://raw.githubusercontent.com/ao-libre/ao-cliente/master/INIT/sinfo.dat")
     Call CargarServidores
-    Call AddtoRichTextBox(frmCargando.Status, "Hecho", 255, 0, 0, True, False, False)
+    Call AddtoRichTextBox(frmCargando.status, "Hecho", 255, 0, 0, True, False, False)
     
     '###########
     ' CONSTANTES
-    Call AddtoRichTextBox(frmCargando.Status, "Iniciando constantes... ", 255, 255, 255, True, False, True)
+    Call AddtoRichTextBox(frmCargando.status, "Iniciando constantes... ", 255, 255, 255, True, False, True)
     Call InicializarNombres
     ' Initialize FONTTYPES
     Call Protocol.InitFonts
@@ -879,7 +876,7 @@ Private Sub LoadInitialConfig()
     
     '#######
     ' CLASES
-    Call AddtoRichTextBox(frmCargando.Status, "Instanciando clases... ", 255, 255, 255, True, False, True)
+    Call AddtoRichTextBox(frmCargando.status, "Instanciando clases... ", 255, 255, 255, True, False, True)
     Set Dialogos = New clsDialogs
     Set Audio = New clsAudio
     Set Inventario = New clsGrapchicalInventory
@@ -893,7 +890,7 @@ Private Sub LoadInitialConfig()
     
     '##############
     ' MOTOR GRAÅFICO
-    Call AddtoRichTextBox(frmCargando.Status, "Iniciando motor grafico... ", 255, 255, 255, True, False, True)
+    Call AddtoRichTextBox(frmCargando.status, "Iniciando motor grafico... ", 255, 255, 255, True, False, True)
     
     '     Iniciamos el Engine de DirectX 8
     If Not Engine_DirectX8_Init Then
@@ -907,21 +904,21 @@ Private Sub LoadInitialConfig()
     
     Engine_DirectX8_Aditional_Init
     
-    Call AddtoRichTextBox(frmCargando.Status, "Hecho", 255, 0, 0, True, False, False)
+    Call AddtoRichTextBox(frmCargando.status, "Hecho", 255, 0, 0, True, False, False)
     
     '###################
     ' ANIMACIONES EXTRAS
-    Call AddtoRichTextBox(frmCargando.Status, "Creando animaciones extra... ", 255, 255, 255, True, False, True)
+    Call AddtoRichTextBox(frmCargando.status, "Creando animaciones extra... ", 255, 255, 255, True, False, True)
     Call CargarTips
     Call CargarArrayLluvia
     Call CargarAnimArmas
     Call CargarAnimEscudos
     Call CargarColores
-    Call AddtoRichTextBox(frmCargando.Status, "Hecho", 255, 0, 0, True, False, False)
+    Call AddtoRichTextBox(frmCargando.status, "Hecho", 255, 0, 0, True, False, False)
     
     '#############
     ' DIRECT SOUND
-    Call AddtoRichTextBox(frmCargando.Status, "Iniciando DirectSound... ", 255, 255, 255, True, False, True)
+    Call AddtoRichTextBox(frmCargando.status, "Iniciando DirectSound... ", 255, 255, 255, True, False, True)
     'Inicializamos el sonido
     Call Audio.Initialize(DirectX, frmMain.hwnd, App.path & "\" & Config_Inicio.DirSonidos & "\", App.path & "\" & Config_Inicio.DirMusica & "\")
     'Enable / Disable audio
@@ -931,10 +928,10 @@ Private Sub LoadInitialConfig()
     'Inicializamos el inventario grafico
     Call Inventario.Initialize(DirectD3D8, frmMain.PicInv, MAX_INVENTORY_SLOTS)
     'Call Audio.MusicMP3Play(App.path & "\MP3\" & MP3_Inicio & ".mp3")
-    Call AddtoRichTextBox(frmCargando.Status, "Hecho", 255, 0, 0, True, False, False)
+    Call AddtoRichTextBox(frmCargando.status, "Hecho", 255, 0, 0, True, False, False)
     
     
-    Call AddtoRichTextBox(frmCargando.Status, "                    °Bienvenido a Argentum Online!", 255, 255, 255, True, False, True)
+    Call AddtoRichTextBox(frmCargando.status, "                    °Bienvenido a Argentum Online!", 255, 255, 255, True, False, True)
 
     'Give the user enough time to read the welcome text
     Call Sleep(500)
@@ -1524,32 +1521,32 @@ Public Sub CargarHechizos()
 '********************************
 On Error GoTo errorH
     Dim PathName As String
-    Dim J As Long
+    Dim j As Long
  
     PathName = App.path & "\init\Hechizos.dat"
     NumHechizos = Val(GetVar(PathName, "INIT", "NumHechizos"))
  
     ReDim Hechizos(1 To NumHechizos) As tHechizos
-    For J = 1 To NumHechizos
-        With Hechizos(J)
-            .Desc = GetVar(PathName, "HECHIZO" & J, "Desc")
-            .PalabrasMagicas = GetVar(PathName, "HECHIZO" & J, "PalabrasMagicas")
-            .Nombre = GetVar(PathName, "HECHIZO" & J, "Nombre")
-            .SkillRequerido = GetVar(PathName, "HECHIZO" & J, "MinSkill")
+    For j = 1 To NumHechizos
+        With Hechizos(j)
+            .Desc = GetVar(PathName, "HECHIZO" & j, "Desc")
+            .PalabrasMagicas = GetVar(PathName, "HECHIZO" & j, "PalabrasMagicas")
+            .Nombre = GetVar(PathName, "HECHIZO" & j, "Nombre")
+            .SkillRequerido = GetVar(PathName, "HECHIZO" & j, "MinSkill")
          
-            If J <> 38 And J <> 39 Then
-                .EnergiaRequerida = GetVar(PathName, "HECHIZO" & J, "StaRequerido")
+            If j <> 38 And j <> 39 Then
+                .EnergiaRequerida = GetVar(PathName, "HECHIZO" & j, "StaRequerido")
                  
-                .HechiceroMsg = GetVar(PathName, "HECHIZO" & J, "HechizeroMsg")
-                .ManaRequerida = GetVar(PathName, "HECHIZO" & J, "ManaRequerido")
+                .HechiceroMsg = GetVar(PathName, "HECHIZO" & j, "HechizeroMsg")
+                .ManaRequerida = GetVar(PathName, "HECHIZO" & j, "ManaRequerido")
              
              
-                .PropioMsg = GetVar(PathName, "HECHIZO" & J, "PropioMsg")
+                .PropioMsg = GetVar(PathName, "HECHIZO" & j, "PropioMsg")
              
-                .TargetMsg = GetVar(PathName, "HECHIZO" & J, "TargetMsg")
+                .TargetMsg = GetVar(PathName, "HECHIZO" & j, "TargetMsg")
             End If
         End With
-    Next J
+    Next j
  
 Exit Sub
  

--- a/CODIGO/TileEngine.bas
+++ b/CODIGO/TileEngine.bas
@@ -36,14 +36,8 @@ Attribute VB_Name = "Mod_TileEngine"
 Option Explicit
 
 #If False Then 'to fix VB fucking up the var names
-    Dim Nombre, PicInv, fx As String
+    Dim Nombre, PicInv, fX As String
 #End If
-
-'Quad Draw
-Public indexList(0 To 5) As Integer
-Public ibQuad As DxVBLibA.Direct3DIndexBuffer8
-Public vbQuadIdx As DxVBLibA.Direct3DVertexBuffer8
-Dim temp_verts(3) As TLVERTEX
 
 Private OffsetCounterX As Single
 Private OffsetCounterY As Single
@@ -175,7 +169,7 @@ Public Type Char
     Escudo As ShieldAnimData
     UsandoArma As Boolean
     
-    fx As Grh
+    fX As Grh
     FxIndex As Integer
     
     Criminal As Byte
@@ -201,7 +195,7 @@ Public Type Char
 End Type
 
 'Info de un objeto
-Public Type Obj
+Public Type obj
     ObjIndex As Integer
     Amount As Integer
 End Type
@@ -213,14 +207,14 @@ Public Type MapBlock
     ObjGrh As Grh
     
     NPCIndex As Integer
-    OBJInfo As Obj
+    OBJInfo As obj
     TileExit As WorldPos
     Blocked As Byte
     
     Trigger As Integer
     Engine_Light(0 To 3) As Long 'Standelf, Light Engine.
     
-    fx As Grh
+    fX As Grh
     FxIndex As Integer
 End Type
 
@@ -838,14 +832,14 @@ Sub MoveScreen(ByVal nHeading As E_Heading)
 End Sub
 
 Private Function HayFogata(ByRef Location As Position) As Boolean
-    Dim J As Long
+    Dim j As Long
     Dim k As Long
     
-    For J = UserPos.X - 8 To UserPos.X + 8
+    For j = UserPos.X - 8 To UserPos.X + 8
         For k = UserPos.Y - 6 To UserPos.Y + 6
-            If InMapBounds(J, k) Then
-                If MapData(J, k).ObjGrh.GrhIndex = GrhFogata Then
-                    Location.X = J
+            If InMapBounds(j, k) Then
+                If MapData(j, k).ObjGrh.GrhIndex = GrhFogata Then
+                    Location.X = j
                     Location.Y = k
                     
                     HayFogata = True
@@ -853,7 +847,7 @@ Private Function HayFogata(ByRef Location As Position) As Boolean
                 End If
             End If
         Next k
-    Next J
+    Next j
 End Function
 
 Function NextOpenChar() As Integer
@@ -1257,9 +1251,9 @@ Sub RenderScreen(ByVal tilex As Integer, ByVal tiley As Integer, ByVal PixelOffs
                     
                     If MapData(X, Y).FxIndex <> 0 Then
                         
-                        Call DDrawTransGrhtoSurface(MapData(X, Y).fx, PixelOffsetXTemp + FxData(.FxIndex).OffsetX, PixelOffsetYTemp + FxData(.FxIndex).OffsetY, 1, MapData(X, Y).Engine_Light(), 1, X, Y, True)
+                        Call DDrawTransGrhtoSurface(MapData(X, Y).fX, PixelOffsetXTemp + FxData(.FxIndex).OffsetX, PixelOffsetYTemp + FxData(.FxIndex).OffsetY, 1, MapData(X, Y).Engine_Light(), 1, X, Y, True)
                         
-                        If MapData(X, Y).fx.Started = 0 Then _
+                        If MapData(X, Y).fX.Started = 0 Then _
                             MapData(X, Y).FxIndex = 0
                     End If
                 End With
@@ -1308,35 +1302,35 @@ Sub RenderScreen(ByVal tilex As Integer, ByVal tiley As Integer, ByVal PixelOffs
     If ClientSetup.ProyectileEngine Then
                             
         If LastProjectile > 0 Then
-            Dim J As Long ' Long siempre en los bucles es mucho mas rapido                       
+            Dim j As Long ' Long siempre en los bucles es mucho mas rapido
                                 
-            For J = 1 To LastProjectile
-                If ProjectileList(J).Grh.GrhIndex Then
+            For j = 1 To LastProjectile
+                If ProjectileList(j).Grh.GrhIndex Then
                     Dim Angle As Single
                     'Update the position
-                    Angle = DegreeToRadian * Engine_GetAngle(ProjectileList(J).X, ProjectileList(J).Y, ProjectileList(J).tX, ProjectileList(J).tY)
-                    ProjectileList(J).X = ProjectileList(J).X + (Sin(Angle) * ElapsedTime * 0.63)
-                    ProjectileList(J).Y = ProjectileList(J).Y - (Cos(Angle) * ElapsedTime * 0.63)
+                    Angle = DegreeToRadian * Engine_GetAngle(ProjectileList(j).X, ProjectileList(j).Y, ProjectileList(j).tX, ProjectileList(j).tY)
+                    ProjectileList(j).X = ProjectileList(j).X + (Sin(Angle) * ElapsedTime * 0.63)
+                    ProjectileList(j).Y = ProjectileList(j).Y - (Cos(Angle) * ElapsedTime * 0.63)
                     
                     'Update the rotation
-                    If ProjectileList(J).RotateSpeed > 0 Then
-                        ProjectileList(J).Rotate = ProjectileList(J).Rotate + (ProjectileList(J).RotateSpeed * ElapsedTime * 0.01)
-                        Do While ProjectileList(J).Rotate > 360
-                            ProjectileList(J).Rotate = ProjectileList(J).Rotate - 360
+                    If ProjectileList(j).RotateSpeed > 0 Then
+                        ProjectileList(j).Rotate = ProjectileList(j).Rotate + (ProjectileList(j).RotateSpeed * ElapsedTime * 0.01)
+                        Do While ProjectileList(j).Rotate > 360
+                            ProjectileList(j).Rotate = ProjectileList(j).Rotate - 360
                         Loop
                     End If
     
                     'Draw if within range
-                    X = ((-minX - 1) * 32) + ProjectileList(J).X + PixelOffsetX + ((10 - TileBufferSize) * 32) - 288 + ProjectileList(J).OffsetX
-                    Y = ((-minY - 1) * 32) + ProjectileList(J).Y + PixelOffsetY + ((10 - TileBufferSize) * 32) - 288 + ProjectileList(J).OffsetY
+                    X = ((-minX - 1) * 32) + ProjectileList(j).X + PixelOffsetX + ((10 - TileBufferSize) * 32) - 288 + ProjectileList(j).OffsetX
+                    Y = ((-minY - 1) * 32) + ProjectileList(j).Y + PixelOffsetY + ((10 - TileBufferSize) * 32) - 288 + ProjectileList(j).OffsetY
                     If Y >= -32 Then
                         If Y <= (ScreenHeight + 32) Then
                             If X >= -32 Then
                                 If X <= (ScreenWidth + 32) Then
-                                    If ProjectileList(J).Rotate = 0 Then
-                                        DDrawTransGrhtoSurface ProjectileList(J).Grh, X, Y, 0, MapData(50, 50).Engine_Light(), 0, 50, 50, True, 0
+                                    If ProjectileList(j).Rotate = 0 Then
+                                        DDrawTransGrhtoSurface ProjectileList(j).Grh, X, Y, 0, MapData(50, 50).Engine_Light(), 0, 50, 50, True, 0
                                     Else
-                                        DDrawTransGrhtoSurface ProjectileList(J).Grh, X, Y, 0, MapData(50, 50).Engine_Light(), 0, 50, 50, True, ProjectileList(J).Rotate
+                                        DDrawTransGrhtoSurface ProjectileList(j).Grh, X, Y, 0, MapData(50, 50).Engine_Light(), 0, 50, 50, True, ProjectileList(j).Rotate
                                     End If
                                 End If
                             End If
@@ -1344,18 +1338,18 @@ Sub RenderScreen(ByVal tilex As Integer, ByVal tiley As Integer, ByVal PixelOffs
                     End If
                     
                 End If
-            Next J
+            Next j
             
             'Check if it is close enough to the target to remove
-            For J = 1 To LastProjectile
-                If ProjectileList(J).Grh.GrhIndex Then
-                    If Abs(ProjectileList(J).X - ProjectileList(J).tX) < 20 Then
-                        If Abs(ProjectileList(J).Y - ProjectileList(J).tY) < 20 Then
-                            Engine_Projectile_Erase J
+            For j = 1 To LastProjectile
+                If ProjectileList(j).Grh.GrhIndex Then
+                    If Abs(ProjectileList(j).X - ProjectileList(j).tX) < 20 Then
+                        If Abs(ProjectileList(j).Y - ProjectileList(j).tY) < 20 Then
+                            Engine_Projectile_Erase j
                         End If
                     End If
                 End If
-            Next J
+            Next j
             
         End If
     End If
@@ -1462,16 +1456,7 @@ On Error GoTo 0
     Call CargarCascos
     Call CargarFxs
     Call LoadGraphics
-    
-    'Index Buffer. Dunkan
-    indexList(0) = 0: indexList(1) = 1: indexList(2) = 2
-    indexList(3) = 3: indexList(4) = 4: indexList(5) = 5
-    
-    Set ibQuad = DirectDevice.CreateIndexBuffer(Len(indexList(0)) * 4, 0, D3DFMT_INDEX16, D3DPOOL_MANAGED)
-    D3DIndexBuffer8SetData ibQuad, 0, Len(indexList(0)) * 4, 0, indexList(0)
-    
-    Set vbQuadIdx = DirectDevice.CreateVertexBuffer(Len(temp_verts(0)) * 4, 0, D3DFVF_XYZ Or D3DFVF_DIFFUSE Or D3DFVF_SPECULAR Or D3DFVF_TEX1, D3DPOOL_MANAGED)
-    
+
     InitTileEngine = True
 End Function
 Public Sub LoadGraphics()
@@ -1482,7 +1467,7 @@ End Sub
 Sub ShowNextFrame(ByVal DisplayFormTop As Integer, ByVal DisplayFormLeft As Integer, ByVal MouseViewX As Integer, ByVal MouseViewY As Integer)
 
     If EngineRun Then
-        Call Engine_Clear
+        Call Engine_BeginScene
         
         If UserMoving Then
             '****** Move screen Left and Right if needed ******
@@ -1528,7 +1513,7 @@ Sub ShowNextFrame(ByVal DisplayFormTop As Integer, ByVal DisplayFormLeft As Inte
         timerElapsedTime = GetElapsedTime()
         timerTicksPerFrame = timerElapsedTime * Engine_Get_BaseSpeed
         
-        Call Engine_Present(MainScreenRect, 0)
+        Call Engine_EndScene(MainScreenRect, 0)
     End If
     
     
@@ -1847,10 +1832,10 @@ Private Sub CharRender(ByVal CharIndex As Long, ByVal PixelOffsetX As Integer, B
         Movement_Speed = 1
         'Draw FX
         If .FxIndex <> 0 Then
-            Call DDrawTransGrhtoSurface(.fx, PixelOffsetX + FxData(.FxIndex).OffsetX, PixelOffsetY + FxData(.FxIndex).OffsetY, 1, SetARGB_Alpha(MapData(.Pos.X, .Pos.Y).Engine_Light(), 180), 1, .Pos.X, .Pos.Y, True)
+            Call DDrawTransGrhtoSurface(.fX, PixelOffsetX + FxData(.FxIndex).OffsetX, PixelOffsetY + FxData(.FxIndex).OffsetY, 1, SetARGB_Alpha(MapData(.Pos.X, .Pos.Y).Engine_Light(), 180), 1, .Pos.X, .Pos.Y, True)
             
             'Check if animation is over
-            If .fx.Started = 0 Then _
+            If .fX.Started = 0 Then _
                 .FxIndex = 0
         End If
         
@@ -1892,19 +1877,19 @@ Private Sub RenderName(ByVal CharIndex As Long, ByVal X As Integer, ByVal Y As I
     End With
 End Sub
 
-Public Sub SetCharacterFx(ByVal CharIndex As Integer, ByVal fx As Integer, ByVal Loops As Integer)
+Public Sub SetCharacterFx(ByVal CharIndex As Integer, ByVal fX As Integer, ByVal Loops As Integer)
 '***************************************************
 'Author: Juan Martín Sotuyo Dodero (Maraxus)
 'Last Modify Date: 12/03/04
 'Sets an FX to the character.
 '***************************************************
     With charlist(CharIndex)
-        .FxIndex = fx
+        .FxIndex = fX
         
         If .FxIndex > 0 Then
-            Call InitGrh(.fx, FxData(fx).Animacion)
+            Call InitGrh(.fX, FxData(fX).Animacion)
         
-            .fx.Loops = Loops
+            .fX.Loops = Loops
         End If
     End With
 End Sub
@@ -1954,13 +1939,8 @@ Public Sub Device_Textured_Render(ByVal X As Integer, ByVal Y As Integer, ByVal 
     End If
     
     ' Medium load.
-    'DirectDevice.DrawPrimitiveUP D3DPT_TRIANGLESTRIP, 2, temp_verts(0), Len(temp_verts(0))
-        
-    ' Faster load.
-    DirectDevice.DrawIndexedPrimitiveUP D3DPT_TRIANGLESTRIP, 0, 4, 2, _
-                indexList(0), D3DFMT_INDEX16, _
-                temp_verts(0), Len(temp_verts(0))
-                
+    DirectDevice.DrawPrimitiveUP D3DPT_TRIANGLESTRIP, 2, temp_verts(0), Len(temp_verts(0))
+
     If alpha Then
         DirectDevice.SetRenderState D3DRS_SRCBLEND, D3DBLEND_SRCALPHA
         DirectDevice.SetRenderState D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA
@@ -2014,11 +1994,11 @@ Public Sub RenderItem(ByVal hWndDest As Long, ByVal GrhIndex As Long)
         .bottom = 32
     End With
     
-    Engine_Clear
+    Call Engine_BeginScene
 
     Call DDrawTransGrhIndextoSurface(GrhIndex, 0, 0, 0, Normal_RGBList(), 0, False)
         
-    Engine_Present DR, hWndDest
+    Call Engine_EndScene(DR, hWndDest)
     
 End Sub
 

--- a/CODIGO/clsGrapchicalInventory.cls
+++ b/CODIGO/clsGrapchicalInventory.cls
@@ -405,12 +405,12 @@ Private Sub DrawInventory()
     
     'Clear the inventory window
     
-    Engine_Clear
+    Call Engine_BeginScene
     
         For LoopC = InventoryOffset * (InventoryWindow.ScaleWidth \ ownTilePixelWidth) + 1 To UBound(Inventory)
             
-            startdX = ((LoopC - 1) Mod (frmMain.PicInv.Width / 32)) * 32
-            startdY = ((LoopC - 1) \ (frmMain.PicInv.Width / 32)) * 32
+            startdX = ((LoopC - 1) Mod (frmMain.picInv.Width / 32)) * 32
+            startdY = ((LoopC - 1) \ (frmMain.picInv.Width / 32)) * 32
             
             
             Call Engine_Long_To_RGB_List(Inv_Color(), -1)
@@ -439,7 +439,7 @@ Private Sub DrawInventory()
             End If
         Next LoopC
         
-    Engine_Present destRect, InventoryWindow.hwnd
+    Call Engine_EndScene(destRect, InventoryWindow.hwnd)
     
 End Sub
 

--- a/CODIGO/mDx8_Engine.bas
+++ b/CODIGO/mDx8_Engine.bas
@@ -22,6 +22,7 @@ Public Type TLVERTEX
   Z As Single
   rhw As Single
   Color As Long
+  Specular As Long
   tu As Single
   tv As Single
 End Type
@@ -45,8 +46,6 @@ Public Function Engine_DirectX8_Init() As Boolean
         .BackBufferFormat = DispMode.Format
         .BackBufferWidth = frmMain.MainViewPic.ScaleWidth
         .BackBufferHeight = frmMain.MainViewPic.ScaleHeight
-        .EnableAutoDepthStencil = 0
-        .AutoDepthStencilFormat = 0
         .hDeviceWindow = frmMain.MainViewPic.hwnd
     End With
 
@@ -79,7 +78,7 @@ Public Function Engine_DirectX8_Init() As Boolean
     Engine_Init_FontTextures
     Engine_Init_FontSettings
     
-    DirectDevice.SetVertexShader D3DFVF_XYZRHW Or D3DFVF_DIFFUSE Or D3DFVF_TEX1
+    DirectDevice.SetVertexShader D3DFVF_XYZRHW Or D3DFVF_DIFFUSE Or D3DFVF_TEX1 Or D3DFVF_SPECULAR
     DirectDevice.SetRenderState D3DRS_LIGHTING, False
     DirectDevice.SetRenderState D3DRS_SRCBLEND, D3DBLEND_SRCALPHA
     DirectDevice.SetRenderState D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA
@@ -470,26 +469,11 @@ Public Sub Engine_BeginScene(Optional ByVal Color As Long = 0)
 '***************************************************
 
     DirectDevice.BeginScene
-
-End Sub
-
-Public Sub Engine_Clear(Optional ByVal Color As Long = 0)
-
     DirectDevice.Clear 0, ByVal 0, D3DCLEAR_TARGET, Color, 1#, 0
     
 End Sub
 
-Public Sub Engine_Present(ByRef destRect As RECT, Optional ByVal hWndDest As Long = 0)
-    
-    If hWndDest = 0 Then
-        DirectDevice.Present destRect, ByVal 0&, ByVal 0&, ByVal 0&
-    Else
-        DirectDevice.Present destRect, ByVal 0, hWndDest, ByVal 0
-    End If
-    
-End Sub
-
-Public Sub Engine_EndScene()
+Public Sub Engine_EndScene(ByRef destRect As RECT, Optional ByVal hWndDest As Long = 0)
 '***************************************************
 'Author: Ezequiel Juárez (Standelf)
 'Last Modification: 29/12/10
@@ -497,6 +481,12 @@ Public Sub Engine_EndScene()
 '***************************************************
     
     DirectDevice.EndScene
+        
+    If hWndDest = 0 Then
+        DirectDevice.Present destRect, ByVal 0&, ByVal 0&, ByVal 0&
+    Else
+        DirectDevice.Present destRect, ByVal 0, hWndDest, ByVal 0
+    End If
     
 End Sub
 


### PR DESCRIPTION
Should only be one BeginScene() and EndScene(), but requires to present each swapchain at the end of EndScene() and not within. There is a memory corruption somewhere related to Direct3D that corrupts everything (Once found, FVF_SPECULAR and Specular variable should be removed).