### PR TITLE
Parche: Eliminados links muertos frmOpciones

### DIFF
--- a/CODIGO/frmOpciones.frm
+++ b/CODIGO/frmOpciones.frm
@@ -221,10 +221,10 @@ Attribute VB_PredeclaredId = True
 Attribute VB_Exposed = False
 'Argentum Online 0.11.6
 '
-'Copyright (C) 2002 Márquez Pablo Ignacio
+'Copyright (C) 2002 MÃ¡rquez Pablo Ignacio
 'Copyright (C) 2002 Otto Perez
 'Copyright (C) 2002 Aaron Perkins
-'Copyright (C) 2002 Matías Fernando Pequeño
+'Copyright (C) 2002 MatÃ­as Fernando PequeÃ±o
 '
 'This program is free software; you can redistribute it and/or modify
 'it under the terms of the Affero General Public License;
@@ -246,10 +246,10 @@ Attribute VB_Exposed = False
 'You can contact me at:
 'morgolock@speedy.com.ar
 'www.geocities.com/gmorgolock
-'Calle 3 número 983 piso 7 dto A
+'Calle 3 nÃºmero 983 piso 7 dto A
 'La Plata - Pcia, Buenos Aires - Republica Argentina
-'Código Postal 1900
-'Pablo Ignacio Márquez
+'CÃ³digo Postal 1900
+'Pablo Ignacio MÃ¡rquez
 
 Option Explicit
 
@@ -432,7 +432,7 @@ End Sub
 Private Sub imgManual_Click()
     If Not loading Then _
         Call Audio.PlayWave(SND_CLICK)
-    Call ShellExecute(0, "Open", "http://ao.alkon.com.ar/manual/", "", App.path, SW_SHOWNORMAL)
+    Call ShellExecute(0, "Open", "https://github.com/ao-libre/ao-cliente/blob/master/README.md", "", App.path, SW_SHOWNORMAL)
 End Sub
 
 Private Sub imgMapa_Click()
@@ -441,13 +441,6 @@ End Sub
 
 Private Sub imgMsgPersonalizado_Click()
     Call frmMessageTxt.Show(vbModeless, Me)
-End Sub
-
-Private Sub imgRadio_Click()
-    If Not loading Then _
-        Call Audio.PlayWave(SND_CLICK)
-
-    Call ShellExecute(0, "Open", "http://www.radioargentum.com/repro.html", "", App.path, SW_SHOWNORMAL)
 End Sub
 
 Private Sub imgSalir_Click()
@@ -460,7 +453,7 @@ Private Sub imgSoporte_Click()
     If Not loading Then _
         Call Audio.PlayWave(SND_CLICK)
     
-    Call ShellExecute(0, "Open", "http://www.aostaff.com.ar/soporte/", "", App.path, SW_SHOWNORMAL)
+    Call ShellExecute(0, "Open", "https://github.com/ao-libre/ao-cliente/issues", "", App.path, SW_SHOWNORMAL)
 End Sub
 
 Private Sub imgTutorial_Click()


### PR DESCRIPTION
El imgRadio, lo borré.
El imgManual, te redirige al README.md.
El de imgSoporte, te redirige a la pestaña `Issues` de la repo.

Closes #64 