### PR TITLE
Fix: Mini-Mapa en Render con lectura de Imágenes.

### DIFF
--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -1065,7 +1065,7 @@ Private Sub LoadInitialConfig()
     Engine_DirectX8_Aditional_Init
     
     Call mDx8_Minimap.MiniMap_Init
-    Dx8_Minimap.AlphaMiniMap = 205                                                                                                                
+    mDx8_Minimap.AlphaMiniMap = 205
     
     
     Call AddtoRichTextBox(frmCargando.status, _

--- a/CODIGO/mDx8_Minimap.bas
+++ b/CODIGO/mDx8_Minimap.bas
@@ -51,7 +51,9 @@ Public Sub MiniMap_Init()
 End Sub
 
 Public Sub MiniMap_Render(ByVal X As Long, ByVal Y As Long)
-
+    
+    If Not FileExist(App.path & "\Graficos\MiniMapa\" & UserMap & ".bmp", vbArchive) Then Exit Sub
+    
     Dim VertexArray(0 To 3) As TLVERTEX
     Dim SrcWidth            As Integer
     Dim Width               As Integer
@@ -209,15 +211,6 @@ Public Sub MiniMap_ChangeTex(UserMap As Integer)
     End With
 
     Exit Sub
-
-eDebug:
-
-    If Err.number = "-2005529767" Then
-        MsgBox "No se encuentra la textura del mini-mapa correspondiente a este mapa.", vbCritical, "Mini-Mapa"
-               
-    End If
-
-    Call CloseClient
 
 End Sub
 


### PR DESCRIPTION
Cuando entrabas a un mapa que no tenia su .bmp en la carpeta "Graficos\MiniMapa", se cerraba el cliente.