### PR TITLE
Mejora - daño en render.

### DIFF
--- a/CODIGO/Declares.bas
+++ b/CODIGO/Declares.bas
@@ -150,6 +150,8 @@ End Enum
 
 Public ColoresPJ(0 To 50) As Long
 
+Public ColoresDano(51 To 56) As Long
+
 Public Type tServerInfo
     Ip As String
     Puerto As Integer

--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -118,9 +118,10 @@ End Sub
 
 
 Public Sub CargarColores()
+
 On Error Resume Next
-    Dim archivoC As String
-    archivoC = App.path & "\init\colores.dat"
+    
+    Dim archivoC As String: archivoC = App.path & "\init\colores.dat"
     
     If Not FileExist(archivoC, vbArchive) Then
         Call MsgBox("ERROR: no se ha podido cargar los colores. Falta el archivo colores.dat, reinstale el juego", vbCritical + vbOKOnly)
@@ -141,6 +142,11 @@ On Error Resume Next
     
     '   Atacable TODO: hay que implementar un color para los atacables y hacer que funcione.
     'ColoresPJ(48) = D3DColorXRGB(GetVar(archivoC, "AT", "R"), GetVar(archivoC, "AT", "G"), GetVar(archivoC, "AT", "B"))
+    
+    For i = 51 To 56 'Colores reservados para la renderizacion de dano
+        ColoresDano(i) = D3DColorXRGB(GetVar(archivoC, CStr(i), "R"), GetVar(archivoC, CStr(i), "G"), GetVar(archivoC, CStr(i), "B"))
+    Next i
+    
 End Sub
 
 Sub CargarAnimEscudos()

--- a/CODIGO/mDx8_Dibujado.bas
+++ b/CODIGO/mDx8_Dibujado.bas
@@ -20,10 +20,12 @@ Private Const DAMAGE_TIME As Integer = 40
 Private Const DAMAGE_FONT_S As Byte = 12
  
 Private Enum EDType
-     edPunal = 1                'Apunalo.
-     edNormal = 2               'Hechizo o golpe común.
-     edCritico = 3              'Golpe Critico
-     edFallo = 4                'Fallo el ataque
+     edPunal = 1    'Apunalo.
+     edNormal = 2   'Hechizo o golpe común.
+     edCritico = 3  'Golpe Critico
+     edFallo = 4    'Fallo el ataque
+     edCurar = 5    'Curacion a usuario
+     edTrabajo = 6  'Cantidad de items obtenidas a partir del trabajo realizado
 End Enum
  
 Private DNormalFont    As New StdFont
@@ -195,10 +197,16 @@ Sub Damage_Draw(ByVal X As Byte, _
                 Case EDType.edCritico
                     DrawText PixelX, PixelY - .Downloading, "¡-" & .DamageVal & "!", .ColorRGB
                 
+                Case EDType.edCurar
+                    DrawText PixelX, PixelY - .Downloading, "+" & .DamageVal, .ColorRGB
+                
+                Case EDType.edTrabajo
+                    DrawText PixelX, PixelY - .Downloading, "+" & .DamageVal, .ColorRGB
+                    
                 Case EDType.edFallo
                     DrawText PixelX, PixelY - .Downloading, "Fallo", .ColorRGB
                     
-                Case Else
+                Case Else 'EDType.edNormal
                     DrawText PixelX, PixelY - .Downloading, "-" & .DamageVal, .ColorRGB
                     
             End Select
@@ -237,14 +245,20 @@ Function Damage_ModifyColour(ByVal TimeNowRendered As Byte, _
     Select Case DamageType
                    
         Case EDType.edPunal
-            Damage_ModifyColour = D3DColorXRGB(255, 255, 255)
-                   
-        Case EDType.edNormal
-            Damage_ModifyColour = D3DColorXRGB(200, 200, 11)
+            Damage_ModifyColour = ColoresDano(52)
             
         Case EDType.edFallo
-            Damage_ModifyColour = D3DColorXRGB(200, 0, 0)
-       
+            Damage_ModifyColour = ColoresDano(54)
+            
+        Case EDType.edCurar
+            Damage_ModifyColour = ColoresDano(55)
+        
+        Case EDType.edTrabajo
+            Damage_ModifyColour = ColoresDano(56)
+            
+        Case Else 'EDType.edNormal
+            Damage_ModifyColour = ColoresDano(51)
+            
     End Select
  
 End Function

--- a/Changelog-client.txt
+++ b/Changelog-client.txt
@@ -1,4 +1,4 @@
----------------------------------------
+﻿---------------------------------------
 ARGENTUM ONLINE - CHANGELOG DEL CLIENTE
 ---------------------------------------
 
@@ -383,8 +383,26 @@ http://www.aivosto.com/articles/stringopt.html (jopiortiz)
 * 11/03/2019 : Eliminada la carga de MD5. (jopiortiz)
 
 - 0.13.8
-* 12/03/2019: Implementación: Sistema de Quests via NPC's. (jopiortiz)
-* 12/03/2019: Optimizaciones varias, limpieza de codigo (jopiortiz)
+* 12/03/2019 : Implementación: Sistema de Quests via NPC's. (jopiortiz)
+* 12/03/2019 : Optimizaciones varias, limpieza de codigo (jopiortiz)
 * 14/03/2019 : Implementación: Amuleto del Silencio (Recox-jopiortiz)
 * 15/03/2019 : Reemplazados caracteres especiales por normales (à á é í ó ú ñ Ñ) para evitar errores en encodeo y diferencias de codigo no deseadas en pull requests. (Recox)
+* 20/03/2019 : Arreglado desde el codigo la obtencion de una propiedad inexistente al json de lenguajes (Recox)
+* 22/03/2019 : Fix: Agregué una validacion (¿sos gm?) antes de abrir el frmBuscar. (jopiortiz)
+* 27/03/2019 : Cambie el link del Manual y de las Reglas (Recox)
+* 01/04/2019 : Se implemento la posibilidad de que cada servidor pueda elegir su propio mundo, el mismo se selecciona desde la propiedad Mundo en el archivo sinfo.dat (Recox)
 
+- 0.13.8.1
+* 04/04/2019 : Se usa el numero de versionTagRelease desde el archivo INIT\Config.ini para mostrar la version de juego en el render (Recox)
+* 04/04/2019 : Se creo un boton para poder refrescar la lista de servidores (Recox)
+* 04/04/2019 : Se simplifico el formulario de conectar borrando codigo innecesario (Recox)
+
+- 0.13.8.2
+* 08/04/2019 : Ahora la aplicacion no crashea al tratar de abrirla sin internet. (Recox)
+* 08/04/2019 : Se agregaron todas las imagenes de minimapa faltantes (Recox)
+* 08/04/2019 : Se modifico un poco el mapa 273 del battleserver y el 198 del deathmatch (Recox)
+* 09/04/2019 : Ahora los sacerdotes de abajo y arriba curan en mapa deathmatch (198) (Recox)
+
+- 0.13.8.3
+* 11/04/2019: Se convirtio el mapa Escondrijo de las ruinas de earost en el mundo deathmatch con todos los npcs necesarios para un agite rapido. (Recox)
+* 14/04/2019: Implementación - daño en render. (jopiortiz)

--- a/INIT/colores.dat
+++ b/INIT/colores.dat
@@ -281,3 +281,44 @@ B=0
 R=0
 G=0
 B=0
+
+[50]
+R=0
+G=0
+B=0
+
+# Daño - Normal
+[51]
+R=0
+G=179
+B=0
+
+# Daño - Puñal
+[52]
+R=255
+G=51
+B=85
+
+# Daño - Critico
+[53]
+R=0
+G=0
+B=0
+
+# Daño - "Falló"
+[54]
+R=30
+G=179
+B=0
+
+# Render - Curar
+[55]
+R=173
+G=216
+B=230
+
+# Render - Trabajo
+[56]
+R=173
+G=216
+B=230


### PR DESCRIPTION
Ahora se renderiza:

- Cuando un user ATACA a un NPC y viceversa.
- Cuando un user CURA a un NPC o User y viceversa.
- Cuando un elemental ataca a un NPC o user y viceversa.
- Cuando un user FALLA un ataque a otro user o npc y viceversa.
- Cuando un user obtiene un objeto al trabajar. Aparece un "+1" arriba de tu cabeza.
- El mana recuperado al meditar. Aparece un "+valor recuperado" arriba de tu cabeza.

Los colores en los diferentes casos pueden cambiarse desde `colores.dat`