### PR TITLE
Arreglado: Comportamiento de el cambio de resolución.

### DIFF
--- a/CODIGO/Declares.bas
+++ b/CODIGO/Declares.bas
@@ -172,8 +172,6 @@ Public Site As String
 Public UserCiego As Boolean
 Public UserEstupido As Boolean
 
-Public NoRes As Boolean 'no cambiar la resolucion
-
 Public RainBufferIndex As Long
 Public FogataBufferIndex As Long
 

--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -889,7 +889,7 @@ Sub Main()
     tipf = Config_Inicio.tip
     
     'Set resolution BEFORE the loading form is displayed, therefore it will be centered.
-    Call Resolution.SetResolution
+    Call Resolution.SetResolution(800, 600)
 
     ' Load constants, classes, flags, graphics..
     LoadInitialConfig

--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -1267,8 +1267,10 @@ Public Sub LeerLineaComandos()
     
     For i = Lower_t To Upper_t
         Select Case UCase$(T(i))
-            Case "/NORES" 'no cambiar la resolucion
-                NoRes = True
+            Case "/NORES" 'NO cambiar la resolucion
+                PuedeCambiarResolucion = False
+            Case Else     'SI cambiar la resolucion
+                PuedeCambiarResolucion = True
         End Select
     Next i
 
@@ -1292,8 +1294,6 @@ Private Sub LoadClientSetup()
         'Use dynamic by default
         ClientSetup.bDinamic = True
     End If
-    
-    NoRes = ClientSetup.bNoRes
     
     ClientSetup.bGuildNews = Not ClientSetup.bGuildNews
     Set DialogosClanes = New clsGuildDlg

--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -889,7 +889,7 @@ Sub Main()
     tipf = Config_Inicio.tip
     
     'Set resolution BEFORE the loading form is displayed, therefore it will be centered.
-    Call Resolution.SetResolution(800, 600)
+    Call Resolution.ChangeResolution
 
     ' Load constants, classes, flags, graphics..
     LoadInitialConfig
@@ -1102,7 +1102,7 @@ Private Sub LoadInitialConfig()
                             True, False, False)
     
     'Inicializamos el inventario grafico
-    Call Inventario.Initialize(DirectD3D8, frmMain.PicInv, MAX_INVENTORY_SLOTS)
+    Call Inventario.Initialize(DirectD3D8, frmMain.picInv, MAX_INVENTORY_SLOTS)
     
     Call AddtoRichTextBox(frmCargando.status, _
                             "                    " & JsonLanguage.Item("BIENVENIDO").Item("TEXTO"), _
@@ -1444,7 +1444,7 @@ Public Sub CloseClient()
     Call EscribirGameIni(Config_Inicio)
     
     ' Si esta en pantalla completa, volvemos a la resolucion original
-    If Resolution.GetResolutionState Then Call Resolution.ResetResolution
+    If ResolucionCambiada Then Call Resolution.ResetResolution
     
     End
     

--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -1411,14 +1411,12 @@ Public Sub CloseClient()
     
     EngineRun = False
     
-    Call Resolution.ResetResolution
-    
     #If UsarWrench = 1 Then
-            frmMain.Socket1.Disconnect
-            frmMain.Socket1.Flush
-            frmMain.Socket1.Cleanup
+        frmMain.Socket1.Disconnect
+        frmMain.Socket1.Flush
+        frmMain.Socket1.Cleanup
     #Else
-            frmMain.Winsock1.Close
+        frmMain.Winsock1.Close
     #End If
     
     'Stop tile engine
@@ -1444,6 +1442,9 @@ Public Sub CloseClient()
     'Actualizar tip
     Config_Inicio.tip = tipf
     Call EscribirGameIni(Config_Inicio)
+    
+    ' Si esta en pantalla completa, volvemos a la resolucion original
+    If Resolution.GetResolutionState Then Call Resolution.ResetResolution
     
     End
     

--- a/CODIGO/Resolution.bas
+++ b/CODIGO/Resolution.bas
@@ -44,7 +44,7 @@ Attribute VB_Name = "Resolution"
 Option Explicit
 
 Public ResolucionCambiada As Boolean        ' Se cambio la resolucion?
-Public NoRes As Boolean
+Public PuedeCambiarResolucion As Boolean
 
 Private Const CCDEVICENAME As Long = 32
 Private Const CCFORMNAME As Long = 32
@@ -136,7 +136,7 @@ Public Sub SetResolution(ByRef newWidth As Integer, ByRef newHeight As Integer)
 
             ' Se cambió la resolución
             ResolucionCambiada = True
-            NoRes = True
+
         Else
             
             ' Maximizo la vantana
@@ -144,7 +144,7 @@ Public Sub SetResolution(ByRef newWidth As Integer, ByRef newHeight As Integer)
                         
             ' No se cambió la resolución
             ResolucionCambiada = False
-            NoRes = False
+
         End If
         
     End If
@@ -156,32 +156,38 @@ Public Sub ChangeResolution()
     '**********************************************************************************************************************
     'Autor: Jopi
     'A diferencia de SetResolution(), este sub evalua las condiciones previas a preguntar por el cambio de resolucion
+    'Le damos prioridad al parametro /NORES del ejecutable del juego
     '**********************************************************************************************************************
     
-    ' Si es la primera vez que jugamos, preguntamos si queremos mostrar el dialogo de cambio de resolucion la proxima vez que abramos el juego.
-    If PrimeraVez Then
-        If MsgBox(JsonLanguage.Item("PRIMERA_VEZ_PANTALLA_COMPLETA").Item("TEXTO"), vbYesNo, "Argentum Online") = vbYes Then
-            Call WriteVar(DirInit & "Config.ini", "Cliente", "CambiarResolucion", 1)
-            Exit Sub
-        Else
-            Call WriteVar(DirInit & "Config.ini", "Cliente", "CambiarResolucion", 0)
-            Exit Sub
-        End If
+    Select Case PuedeCambiarResolucion
+    
+        Case True
 
-    End If
-    
-    If GetVar(DirInit & "Config.ini", "Cliente", "CambiarResolucion") = 1 Then
+            ' Si es la primera vez que jugamos, preguntamos si queremos mostrar el dialogo de cambio de resolucion la proxima vez que abramos el juego.
+            If PrimeraVez Then
         
-        Call SetResolution(800, 600)
-        
-    Else
-        ' Maximizo la vantana
-        frmMain.WindowState = vbNormal
-                        
-        ' No se cambió la resolución
-        ResolucionCambiada = False
-    End If
-    
+                If MsgBox(JsonLanguage.Item("PRIMERA_VEZ_PANTALLA_COMPLETA").Item("TEXTO"), vbYesNo, "Argentum Online") = vbYes Then
+                    Call WriteVar(DirInit & "Config.ini", "Cliente", "CambiarResolucion", 1)
+                Else
+                    Call WriteVar(DirInit & "Config.ini", "Cliente", "CambiarResolucion", 0)
+
+                End If
+
+            End If
+   
+            ' Buscamos en el Config.ini si puede cambiar la resolucion, de ser asi, la cambiamos
+            If GetVar(DirInit & "Config.ini", "Cliente", "CambiarResolucion") = 1 Then Call SetResolution(800, 600)
+            
+        Case False
+
+            ' Maximizo la vantana
+            frmMain.WindowState = vbNormal
+                            
+            ' No se cambió la resolución
+            ResolucionCambiada = False
+
+    End Select
+
 End Sub
 
 Public Sub ResetResolution()

--- a/CODIGO/frmMain.frm
+++ b/CODIGO/frmMain.frm
@@ -1233,6 +1233,16 @@ Private Sub Form_KeyUp(KeyCode As Integer, Shift As Integer)
             End If
         End If
         
+        'If KeyCode = vbKeyF11 Then
+            'If Not ResolucionCambiada Then
+            '    Call SetResolution(800, 600)
+            '    Engine_DirectX8_Init
+            'Else
+            '    Call Resolution.ResetResolution
+            '    Engine_DirectX8_Init
+            'End If
+        'End If
+        
         'Checks if the key is valid
         If LenB(CustomKeys.ReadableName(KeyCode)) > 0 Then
             Select Case KeyCode

--- a/CODIGO/frmMain.frm
+++ b/CODIGO/frmMain.frm
@@ -981,7 +981,7 @@ End Sub
 
 Private Sub Form_Load()
     
-    If NoRes Then
+    If Not ResolucionCambiada Then
         ' Handles Form movement (drag and drop).
         Set clsFormulario = New clsFormMovementManager
         clsFormulario.Initialize Me, 120

--- a/CODIGO/modScreenCapture.bas
+++ b/CODIGO/modScreenCapture.bas
@@ -582,7 +582,7 @@ Public Function FullScreenCapture(ByVal File As String) As Boolean
     
     frmScreenshots.Picture1.AutoRedraw = True
     
-    If NoRes Then
+    If Not ResolucionCambiada Then
         frmScreenshots.Picture1.Width = Screen.Width
         frmScreenshots.Picture1.Height = Screen.Height
         

--- a/INIT/Config.ini
+++ b/INIT/Config.ini
@@ -3,7 +3,7 @@ fileToOpen=\Autoupdate.exe
 
 [Cliente]
 VersionTagRelease=v0.13.8.4
-CambiarResolucion=0
+CambiarResolucion=1
 
 [Parameters]
 SubRedditEndpoint=https://www.reddit.com/r/argentumonlineoficial/.json

--- a/INIT/Config.ini
+++ b/INIT/Config.ini
@@ -3,6 +3,7 @@ fileToOpen=\Autoupdate.exe
 
 [Cliente]
 VersionTagRelease=v0.13.8.4
+CambiarResolucion=0
 
 [Parameters]
 SubRedditEndpoint=https://www.reddit.com/r/argentumonlineoficial/.json

--- a/Lenguajes/english.json
+++ b/Lenguajes/english.json
@@ -976,6 +976,9 @@
 	"PANTALLA_COMPLETA":{
 		"TEXTO":"Do you want to play at full screen?"
 	},
+	"PRIMERA_VEZ_PANTALLA_COMPLETA":{
+		"TEXTO":"It seems to be the first time you play this game, do you wanna be asked if yo want to play at fullscreen?"
+	},
 	"VALIDACION_EMAIL":{
       "TEXTO":"Enter an e-mail."
    },

--- a/Lenguajes/spanish.json
+++ b/Lenguajes/spanish.json
@@ -993,6 +993,9 @@
 	"PANTALLA_COMPLETA":{
 		"TEXTO":"¿Desea jugar en pantalla completa?"
 	},
+	"PRIMERA_VEZ_PANTALLA_COMPLETA":{
+		"TEXTO":"¨Parece que esta es la primera vez que juegas, ¿Quieres que te pregunte si deseas jugar en pantalla completa la próxima vez que abras el juego?"
+	},
 	"VALIDACION_EMAIL":{
 		"TEXTO":"Ingrese un correo electronico."
 	},


### PR DESCRIPTION
- Ya no actualiza la pantalla al elegir "NO" cuando te preguntan de cambiar la resolución.
- Al cerrar el cliente mediante el `Sub CloseClient` estando en pantalla completa, no se reseteaba la resolución. 
- Nueva variable global que chequea si hubo un cambio de resolución al iniciar el juego.
- Si es la primera vez que juegas, te pregunta si querés que te vuelva a preguntar por el cambio de resolución.
- `NoRes` -----> `PuedeCambiarResolucion` . Se sigue respetando el parámetro /NORES del .exe