### PR TITLE
 Chequeamos que la cantidad de items al crear un item en el frmBuscar sea menor o igual a MAX_INVENTORY_OBJS para evitar overflow

### DIFF
--- a/CODIGO/Formularios/frmBuscar.frm
+++ b/CODIGO/Formularios/frmBuscar.frm
@@ -338,6 +338,10 @@ Private Sub mnuCrearObj_Click()
       Exit Sub
    End If
 
+   If LenB(txtCantidad.Text) > 10000 Then 
+      txtCantidad.Text = 10000
+   End If
+
    If ListCrearObj.Visible And LenB(txtCantidad.Text) > 0 Then
       Call WriteCreateItem(ListCrearObj.Text, txtCantidad.Text)
    End If

--- a/CODIGO/Formularios/frmBuscar.frm
+++ b/CODIGO/Formularios/frmBuscar.frm
@@ -333,13 +333,15 @@ Private Sub ListCrearObj_MouseDown(Button As Integer, _
 End Sub
 
 Private Sub mnuCrearObj_Click()
+   'Parche para evitar que no se seleccione un item y al querer crearlo explote el juego (Recox)
    If ListCrearObj.Text = "" Then 
       MsgBox(JsonLanguage.Item("FRMBUSCAR_SELECCIONE_ITEM").Item("TEXTO"))
       Exit Sub
    End If
 
-   If LenB(txtCantidad.Text) > 10000 Then 
-      txtCantidad.Text = 10000
+   'Parche para evitar crear mas items que los permitidos en el inventario y explote el juego (Recox)
+   If LenB(txtCantidad.Text) > MAX_INVENTORY_OBJS Then 
+      txtCantidad.Text = MAX_INVENTORY_OBJS
    End If
 
    If ListCrearObj.Visible And LenB(txtCantidad.Text) > 0 Then
@@ -348,6 +350,7 @@ Private Sub mnuCrearObj_Click()
 End Sub
 
 Private Sub mnuCrearNPC_Click()
+   'Parche para evitar que no se seleccione un item y al querer crearlo explote el juego (Recox)
    If ListCrearNpcs.Text = "" Then 
       MsgBox(JsonLanguage.Item("FRMBUSCAR_SELECCIONE_ITEM").Item("TEXTO"))
       Exit Sub

--- a/Changelog-client.txt
+++ b/Changelog-client.txt
@@ -602,4 +602,5 @@ http://www.aivosto.com/articles/stringopt.html (jopiortiz)
 - v0.13.19
 * 17/12/2019: Se corrigio el numero maximo de items en el inventario para que sea el que usa el server con la alforja puesta (35). (Recox)
 * 17/12/2019: Se arreglo problema en el formulario buscar que hacia que si no seleccionabamos un item antes de tocar el boton crear, el juego crasheaba. (Recox)
+* 17/12/2019: Se arreglo problema en el formulario buscar que hacia que si creabamos mas items que MAX_INVENTORY_OBJS el juego crasheaba. (Recox)
 * 17/12/2019: Se arreglo problema en inventario que nos expulsaba del juego al hacer doble click en un slot vacio. (Recox)


### PR DESCRIPTION
 Chequeamos que la cantidad de items al crear un item en el frmBuscar sea menor o igual a MAX_INVENTORY_OBJS para evitar overflow

