### PR TITLE
Bugfixes frmBuscar y otros

### DIFF
--- a/CODIGO/Formularios/frmBuscar.frm
+++ b/CODIGO/Formularios/frmBuscar.frm
@@ -162,15 +162,18 @@ Attribute VB_PredeclaredId = True
 Attribute VB_Exposed = False
 Option Explicit
 
+Private Declare Function SendMessage Lib "user32" Alias "SendMessageA" (ByVal hWnd As Long, ByVal wMsg As Long, ByVal wParam As Long, ByVal lParam As Long) As Long
+Private Const LB_ITEMFROMPOINT = &H1A9
+
 Private MensajeBusqueda As Boolean
 Private BusquedaObjetos As Boolean
 
-Public Sub AddItem(ByVal num As Integer, ByVal obj As Boolean, data As String)
+Public Sub AddItem(ByVal num As Integer, ByVal Obj As Boolean, data As String)
     Resultados.AddItem data
     Resultados.ItemData(Resultados.ListCount - 1) = num
     
-    If Not Info.Visible Or obj <> BusquedaObjetos Then
-        If obj Then
+    If Not Info.Visible Or Obj <> BusquedaObjetos Then
+        If Obj Then
             Info.Caption = JsonLanguage.item("FRMBUSCAR_INFO_OBJ").item("TEXTO")
         Else
             Info.Caption = JsonLanguage.item("FRMBUSCAR_INFO_NPC").item("TEXTO")
@@ -178,7 +181,11 @@ Public Sub AddItem(ByVal num As Integer, ByVal obj As Boolean, data As String)
         Info.Visible = True
     End If
     
-    BusquedaObjetos = obj
+    BusquedaObjetos = Obj
+End Sub
+
+Private Sub Form_Activate()
+    Me.SetFocus
 End Sub
 
 Private Sub Form_Load()
@@ -202,7 +209,7 @@ Private Sub BuscarObjetos_Click()
     tObjeto = JsonLanguage.item("OBJETO").item("TEXTO")
     
     ' Seamos un poco mas especificos y evitemos un overflow ^-^
-    If Len(Busqueda.Text) < 4 Then
+    If Len(Busqueda.Text) < 2 Then
         MsgBox Replace$(JsonLanguage.item("ERROR_BUSCAR_MUY_CORTO").item("TEXTO"), "VAR_TARGET", tObjeto), vbApplicationModal
         Exit Sub
     End If
@@ -217,7 +224,7 @@ End Sub
 
 Private Sub BuscarNPCs_Click()
     ' Seamos un poco mas especificos y evitemos un overflow ^-^
-    If Len(Busqueda.Text) < 4 Then
+    If Len(Busqueda.Text) < 2 Then
         MsgBox Replace$(JsonLanguage.item("ERROR_BUSCAR_MUY_CORTO").item("TEXTO"), "VAR_TARGET", "NPC"), vbApplicationModal
         Exit Sub
     End If
@@ -243,6 +250,26 @@ Private Sub Limpiarlista_Click()
     Resultados.Clear
 End Sub
 
+Private Sub Resultados_MouseDown(Button As Integer, Shift As Integer, X As Single, Y As Single)
+    Dim Index As Long
+    Dim PosX As Long, PosY As Long
+
+    ' Detectamos el clic derecho para simular la seleccion
+    If Button = vbRightButton Then
+        ' Convertir a pixeles
+        PosX = CLng(X / Screen.TwipsPerPixelX)
+        PosY = CLng(Y / Screen.TwipsPerPixelY)
+        
+        ' Mensaje directo al hWnd usando WinAPI
+        Index = SendMessage(Resultados.hWnd, LB_ITEMFROMPOINT, 0, ByVal ((PosX * 65536) + PosY))
+
+        ' Si seleccionamos un item valido
+        If Index < Resultados.ListCount Then
+            Resultados.ListIndex = Index
+        End If
+    End If
+End Sub
+
 Private Sub Resultados_MouseUp(Button As Integer, Shift As Integer, X As Single, Y As Single)
     If Button = vbRightButton And Resultados.ListIndex >= 0 Then
         If BusquedaObjetos Then
@@ -254,6 +281,8 @@ Private Sub Resultados_MouseUp(Button As Integer, Shift As Integer, X As Single,
 End Sub
 
 Private Sub mnuCrearObj_Click(Index As Integer)
+On Error GoTo errhandler
+
     Dim Numero As Integer
     Dim cantidad As Integer
     
@@ -285,6 +314,11 @@ Private Sub mnuCrearObj_Click(Index As Integer)
     If Numero > 0 Then
         Call WriteCreateItem(Resultados.ItemData(Resultados.ListIndex), cantidad)
     End If
+    Exit Sub
+
+errhandler:
+    cantidad = MAX_INVENTORY_OBJS
+    Resume Next
 End Sub
 
 Private Sub mnuCrearNPC_Click(Index As Integer)

--- a/CODIGO/Formularios/frmBuscar.frm
+++ b/CODIGO/Formularios/frmBuscar.frm
@@ -261,7 +261,7 @@ Private Sub Resultados_MouseDown(Button As Integer, Shift As Integer, X As Singl
         PosY = CLng(Y / Screen.TwipsPerPixelY)
         
         ' Mensaje directo al hWnd usando WinAPI
-        Index = SendMessage(Resultados.hWnd, LB_ITEMFROMPOINT, 0, ByVal ((PosX * 65536) + PosY))
+        Index = SendMessage(Resultados.hWnd, LB_ITEMFROMPOINT, 0, ByVal ((PosY * 65536) + PosX))
 
         ' Si seleccionamos un item valido
         If Index < Resultados.ListCount Then

--- a/CODIGO/Formularios/frmMain.frm
+++ b/CODIGO/Formularios/frmMain.frm
@@ -2624,15 +2624,31 @@ End Sub
 Private Sub Client_DataArrival(ByVal bytesTotal As Long)
     Dim RD     As String
     Dim data() As Byte
+    Dim Length As Long
     
     Client.GetData RD, vbByte, bytesTotal
     data = StrConv(RD, vbFromUnicode)
     
-    'Set data in the buffer
-    Call incomingData.WriteBlock(data)
+    'WyroX: Copiamos hasta llenar la capacidad de la cola.
+    'Si nos pasamos, entonces procesamos los paquetes para vaciarla
+    'y luego volvemos a copiar lo que quede.
+    Do
+        Length = incomingData.Capacity - incomingData.Length
+        Length = IIf(bytesTotal < Length, bytesTotal, Length)
     
-    'Send buffer to Handle data
-    Call HandleIncomingData
+        'Set data in the buffer
+        Call incomingData.WriteBlock(data, Length)
+
+        'Send buffer to Handle data
+        Call HandleIncomingData
+        
+        bytesTotal = bytesTotal - Length
+        
+        If bytesTotal > 0 Then
+            Call CopyMemory(data(0), data(Length), bytesTotal)
+        End If
+        
+    Loop While bytesTotal > 0
     
 End Sub
 

--- a/CODIGO/Formularios/frmMain.frm
+++ b/CODIGO/Formularios/frmMain.frm
@@ -1072,6 +1072,15 @@ Private Declare Function SetWindowLong _
                                         ByVal nIndex As Long, _
                                         ByVal dwNewLong As Long) As Long
 
+''
+' CopyMemory is the fastest way to copy memory blocks, so we abuse of it
+'
+' @param destination Where the data will be copied.
+' @param source The data to be copied.
+' @param length Number of bytes to be copied.
+
+Private Declare Sub CopyMemory Lib "kernel32" Alias "RtlMoveMemory" (ByRef Destination As Any, ByRef source As Any, ByVal Length As Long)
+
 Public Sub dragInventory_dragDone(ByVal originalSlot As Integer, ByVal newSlot As Integer)
     Call Protocol.WriteMoveItem(originalSlot, newSlot, eMoveType.Inventory)
 End Sub

--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -1227,7 +1227,12 @@ Public Sub CloseClient()
     'WyroX:
     'Guardamos antes de cerrar porque algunas configuraciones
     'no se guardan desde el menu opciones (Por ej: M=Musica)
-    Call Game.GuardarConfiguracion
+    'Fix: intentaba guardar cuando el juego cerraba por un error,
+    'antes de cargar los recursos. Me aprovecho de prgRun
+    'para saber si ya fueron cargados
+    If prgRun Then
+        Call Game.GuardarConfiguracion
+    End If
 
     'Cerramos Sockets/Winsocks/WindowsAPI
     frmMain.Client.CloseSck

--- a/CODIGO/Red/Protocol.bas
+++ b/CODIGO/Red/Protocol.bas
@@ -11067,19 +11067,42 @@ errhandler:
 End Sub
 
 Private Sub HandleSearchList()
- 
-        Dim num   As Integer
-        Dim Datos As String
-        Dim obj   As Boolean
+
+On Error GoTo errhandler
+    
+    'This packet contains strings, make a copy of the data to prevent losses if it's not complete yet...
+    Dim Buffer As clsByteQueue
+    Set Buffer = New clsByteQueue
+    Call Buffer.CopyBuffer(incomingData)
+    
+    Dim num   As Integer
+    Dim Datos As String
+    Dim Obj   As Boolean
+    
+    'Remove packet ID
+    Call Buffer.ReadByte
+    
+    num = Buffer.ReadInteger()
+    Obj = Buffer.ReadBoolean()
+    Datos = Buffer.ReadASCIIString()
+    
+    Call frmBuscar.AddItem(num, Obj, Datos)
+    
+    'If we got here then packet is complete, copy data back to original queue
+    Call incomingData.CopyBuffer(Buffer)
         
-        'Remove packet ID
-        Call incomingData.ReadByte
-   
-        num = incomingData.ReadInteger()
-        obj = incomingData.ReadBoolean()
-        Datos = incomingData.ReadASCIIString()
- 
-        Call frmBuscar.AddItem(num, obj, Datos)
+errhandler:
+
+    Dim Error As Long
+
+    Error = Err.number
+
+    On Error GoTo 0
+
+    'Destroy auxiliar buffer
+    Set Buffer = Nothing
+
+    If Error <> 0 Then Err.Raise Error
  
 End Sub
 


### PR DESCRIPTION
Todo lo que hice:
- Fix desbordamiento en frmBuscar con cantidades grandes
- Texto minimo para buscar reducido a 2 caracteres
- Ahora el frmBuscar tiene el foco al abrirse
- Fix al recibir muchos paquetes seguidos sobrepasa el buffer
- Fix guardar config antes de cargar los recursos del cliente
- Ahora con clic derecho seleccionas en la lista de frmBuscar