### PR TITLE
Fixed espada MD, centrado indicador minimapa, removido ActualizarMini…

### DIFF
--- a/CODIGO/Areas/mPooChar.bas
+++ b/CODIGO/Areas/mPooChar.bas
@@ -179,6 +179,8 @@ Public Sub Char_UserPos()
                 bTecho = Char_Techo '// Pos : Techo :P
                
                 frmMain.Coord.Caption = "Map:" & UserMap & " X:" & X & " Y:" & Y
+                
+                Call frmMain.ActualizarMiniMapa
  
                 Exit Sub
  

--- a/CODIGO/Formularios/frmMain.frm
+++ b/CODIGO/Formularios/frmMain.frm
@@ -108,7 +108,7 @@ Begin VB.Form frmMain
          Height          =   225
          Left            =   600
          Top             =   360
-         Width           =   300
+         Width           =   285
       End
       Begin VB.Shape UserM 
          BackColor       =   &H0000FFFF&
@@ -2757,10 +2757,11 @@ Public Sub ActualizarMiniMapa()
     'Last Modify Date: 05/01/2020
     'Integrado por Reyarb
     'Se agrego campo de vision del render (Recox)
+    'Ajustadas las coordenadas para centrarlo (WyroX)
     '***************************************************
-    Me.UserM.Left = UserPos.X
-    Me.UserM.Top = UserPos.Y
-    Me.UserAreaMinimap.Left = UserPos.X - 9
+    Me.UserM.Left = UserPos.X - 2
+    Me.UserM.Top = UserPos.Y - 2
+    Me.UserAreaMinimap.Left = UserPos.X - 10
     Me.UserAreaMinimap.Top = UserPos.Y - 8
     Me.MiniMapa.Refresh
 End Sub

--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -377,8 +377,6 @@ Private Sub CheckKeys()
             Call Char_UserPos
         End If
 
-        Call frmMain.ActualizarMiniMapa   'integrado por ReyarB
-        
     End If
 End Sub
 

--- a/CODIGO/Motor/mDx8_Dibujado.bas
+++ b/CODIGO/Motor/mDx8_Dibujado.bas
@@ -2,7 +2,7 @@ Attribute VB_Name = "mDx8_Dibujado"
 Option Explicit
 
 ' Dano en Render
-Private Const DAMAGE_TIME As Integer = 500
+Private Const DAMAGE_TIME As Integer = 1000
 Private Const DAMAGE_OFFSET As Integer = 20
 Private Const DAMAGE_FONT_S As Byte = 12
  

--- a/CODIGO/Red/Protocol.bas
+++ b/CODIGO/Red/Protocol.bas
@@ -11391,7 +11391,7 @@ Private Sub HandleCreateDamage()
         ' Leemos el ID del paquete.
         .ReadByte
      
-        Call mDx8_Dibujado.Damage_Create(.ReadByte(), .ReadByte(), 0, .ReadInteger(), .ReadByte())
+        Call mDx8_Dibujado.Damage_Create(.ReadByte(), .ReadByte(), 0, .ReadLong(), .ReadByte())
      
     End With
  


### PR DESCRIPTION
…Mapa del main loop y reducida velocidad de danio sobre el char.

Ahora:
- La MD debería funcionar correctamente (Es necesario mergear también en el servidor)
- El indicador del minimapa debería estar mejor centrado y parpadear menos
- El texto del daño sobre los char debería subir más lento