### PR TITLE
Barca sin cabeza

### DIFF
--- a/CODIGO/Red/Protocol.bas
+++ b/CODIGO/Red/Protocol.bas
@@ -11084,6 +11084,8 @@ Private Sub HandleAccountLogged()
                     .weapon = 0
                     .helmet = 0
                     .shield = 0
+                ElseIf (.Body = 397 Or .Body = 395 Or .Body = 399) Then
+                    .Head = 0
                 End If
 
                 .GameMaster = Buffer.ReadBoolean


### PR DESCRIPTION
Se remueve el dibujado de la cabeza en las barcas, galeras y galeones en el PannelAccount.
Solucionado así el siguiente commit: https://github.com/ao-libre/ao-cliente/issues/502