### PR TITLE
Fix - Si no descarga la lista de servers de github arroja error y no deja usar mas el juego

### DIFF
--- a/CODIGO/Formularios/frmConnect.frm
+++ b/CODIGO/Formularios/frmConnect.frm
@@ -943,7 +943,7 @@ Public Sub CargarServidores()
 'Added IP Api to get the country of the IP. (Recox)
 'Get ping from server (Recox)
 '********************************
-On Error GoTo errorH
+On Error Resume Next
     Dim File As String
 
     File = Game.path(INIT) & "sinfo.dat"
@@ -969,11 +969,6 @@ On Error GoTo errorH
     Next i
 
     If CurServer = 0 Then CurServer = 1
-
-Exit Sub
-
-errorH:
-    Call MsgBox("Error cargando los servidores, actualicelos de la web. http://www.ArgentumOnline.org", vbCritical + vbOKOnly, "Argentum Online Libre")
 End Sub
 
 Private Sub DownloadServersFile(myURL As String)
@@ -983,7 +978,6 @@ Private Sub DownloadServersFile(myURL As String)
 'Implemented by Cucsifae
 'Check content of strData to avoid clean the file sinfo.ini if there is no response from Github by Recox
 '**********************************************************
-On Error Resume Next
     Dim strData As String
     Dim f As Integer
 
@@ -995,11 +989,18 @@ On Error Resume Next
 
     f = FreeFile
 
-    If LenB(strData) <> 0 Then
+    Dim is500Error As Boolean 
+    is500Error = InStr(1, strData, "500: Internal Server Error")
+    
+    If LenB(strData) <> 0 And Not is500Error Then
         Open Game.path(INIT) & "sinfo.dat" For Output As #f
             Print #f, strData
         Close #f
     End If
 
+    Exit Sub
+
+Error:
+    Call MsgBox(JsonLanguage.item("ERROR_DESCARGA_SERVIDORES_INET").item("TEXTO") & " " & Err.Description, vbCritical + vbOKOnly, "Argentum Online Libre " & Err.number)
     Exit Sub
 End Sub

--- a/CODIGO/Formularios/frmConnect.frm
+++ b/CODIGO/Formularios/frmConnect.frm
@@ -974,9 +974,10 @@ End Sub
 Private Sub DownloadServersFile(myURL As String)
 '**********************************************************
 'Downloads the sinfo.dat file from a given url
-'Last change: 01/11/2018
+'Last change: 03/04/2020
 'Implemented by Cucsifae
 'Check content of strData to avoid clean the file sinfo.ini if there is no response from Github by Recox
+'If the response from github is error code 500 we don't do anything with the sinfo.dat file Recox
 '**********************************************************
  On Error GoTo Error   
     Dim strData As String

--- a/CODIGO/Formularios/frmConnect.frm
+++ b/CODIGO/Formularios/frmConnect.frm
@@ -978,6 +978,7 @@ Private Sub DownloadServersFile(myURL As String)
 'Implemented by Cucsifae
 'Check content of strData to avoid clean the file sinfo.ini if there is no response from Github by Recox
 '**********************************************************
+ On Error GoTo Error   
     Dim strData As String
     Dim f As Integer
 

--- a/Changelog-client.txt
+++ b/Changelog-client.txt
@@ -716,3 +716,4 @@ http://www.aivosto.com/articles/stringopt.html (jopiortiz)
 -v0.13.29
 * 02/04/2020: Subida de texto mas suave, sin depender de los fps. (FrankoH298)
 * 02/04/2020: Arreglado reconectar al logear, y setAlpha() en drawText. (FrankoH298)
+* 03/04/2020: Si no se puede descargar la lista de servers de github por que tira error 500, no hacemos nada con sinfo.dat. (Recox)

--- a/Lenguajes/english.json
+++ b/Lenguajes/english.json
@@ -659,9 +659,6 @@
     "ERROR_DIRECTDEVICE_INIT": {
         "TEXTO": "Unable to initialize DirectDevice. Please, check if you have your libraries and your drivers up-to-date."
     },
-    "ERROR_DESCARGA_SERVIDORES": {
-        "TEXTO": "Failed to download the server list"
-    },
     "ERROR_DESCARGA_SERVIDORES_INET": {
         "TEXTO": "Failed to download the server list: Error Inet"
     },

--- a/Lenguajes/spanish.json
+++ b/Lenguajes/spanish.json
@@ -659,9 +659,6 @@
     "ERROR_DIRECTDEVICE_INIT": {
         "TEXTO": "No se puede inicializar DirectDevice. Por favor, verifique si tiene sus librerias y sus controladores actualizados."
     },
-    "ERROR_DESCARGA_SERVIDORES": {
-        "TEXTO": "Error al descargar la lista de servidores"
-    },
     "ERROR_DESCARGA_SERVIDORES_INET": {
         "TEXTO": "Error al descargar la lista de servidores: Error de Inet"
     },


### PR DESCRIPTION
Se agrego validacion para que en caso que no se pueda descargar la lista de servers de github, podamos usar la local y seguir usando el juego.