### PR TITLE
Depositar/Retirar items rapido de la boveda con Shift+Click

### DIFF
--- a/CODIGO/Formularios/frmBancoObj.frm
+++ b/CODIGO/Formularios/frmBancoObj.frm
@@ -9,6 +9,7 @@ Begin VB.Form frmBancoObj
    ClipControls    =   0   'False
    ControlBox      =   0   'False
    ForeColor       =   &H8000000F&
+   KeyPreview      =   -1  'True
    LinkTopic       =   "Form1"
    MaxButton       =   0   'False
    MinButton       =   0   'False
@@ -420,6 +421,7 @@ Public LasActionBuy As Boolean
 Public LastIndex1 As Integer
 Public LastIndex2 As Integer
 Public NoPuedeMover As Boolean
+Private Shifteando As Boolean
 
 Private Sub cantidad_Change()
 
@@ -489,6 +491,16 @@ On Error Resume Next
     InvBanco(0).DrawInventory
     InvBanco(1).DrawInventory
 
+End Sub
+
+Private Sub Form_KeyDown(KeyCode As Integer, shift As Integer)
+    
+    If shift = 1 Then Shifteando = True
+End Sub
+
+Private Sub Form_KeyUp(KeyCode As Integer, shift As Integer)
+    
+    If shift <> 1 Then Shifteando = False
 End Sub
 
 Private Sub LoadTextsForm()
@@ -562,6 +574,13 @@ End Sub
 Private Sub PicBancoInv_Click()
 
     If InvBanco(0).SelectedItem <> 0 Then
+
+        If Shifteando Then
+            LasActionBuy = True
+            Call WriteBankExtractItem(InvBanco(0).SelectedItem, 10000)
+            Exit Sub
+        End If
+
         With UserBancoInventory(InvBanco(0).SelectedItem)
             Label1(0).Caption = .name
             
@@ -601,6 +620,13 @@ End Sub
 Private Sub PicInv_Click()
     
     If InvBanco(1).SelectedItem <> 0 Then
+
+        If Shifteando Then
+            LasActionBuy = False
+            Call WriteBankDeposit(InvBanco(1).SelectedItem, 10000)
+            Exit Sub
+        End If
+        
         With Inventario
             Label1(0).Caption = .ItemName(InvBanco(1).SelectedItem)
             

--- a/CODIGO/Formularios/frmBancoObj.frm
+++ b/CODIGO/Formularios/frmBancoObj.frm
@@ -577,7 +577,7 @@ Private Sub PicBancoInv_Click()
 
         If Shifteando Then
             LasActionBuy = True
-            Call WriteBankExtractItem(InvBanco(0).SelectedItem, 10000)
+            Call WriteBankExtractItem(InvBanco(0).SelectedItem, MAX_INVENTORY_OBJS)
             Exit Sub
         End If
 
@@ -623,7 +623,7 @@ Private Sub PicInv_Click()
 
         If Shifteando Then
             LasActionBuy = False
-            Call WriteBankDeposit(InvBanco(1).SelectedItem, 10000)
+            Call WriteBankDeposit(InvBanco(1).SelectedItem, MAX_INVENTORY_OBJS)
             Exit Sub
         End If
         


### PR DESCRIPTION
Inspirado en minecraft, simple y comodo. Cuando apretas shift+click en un item deposita/extrae toda la cantidad de una. video demostrativo:
https://puu.sh/G8wOy.mp4