### PR TITLE
Fix #788: timers de las dopas

### DIFF
--- a/CODIGO/Red/Protocol.bas
+++ b/CODIGO/Red/Protocol.bas
@@ -2060,7 +2060,7 @@ Private Sub HandleUpdateStrenghtAndDexterity()
     frmMain.lblStrg.ForeColor = getStrenghtColor()
     frmMain.lblDext.ForeColor = getDexterityColor()
     IntervaloDopas = incomingData.ReadLong
-    TiempoDopas = (IntervaloDopas * 0.05) - 1
+    TiempoDopas = IntervaloDopas * 0.04
 End Sub
 
 ' Handles the UpdateStrenghtAndDexterity message.
@@ -2084,7 +2084,7 @@ Private Sub HandleUpdateStrenght()
     frmMain.lblStrg.Caption = UserFuerza
     frmMain.lblStrg.ForeColor = getStrenghtColor()
     IntervaloDopas = incomingData.ReadLong
-    TiempoDopas = (IntervaloDopas * 0.05) - 1
+    TiempoDopas = IntervaloDopas * 0.04
 End Sub
 
 ' Handles the UpdateStrenghtAndDexterity message.
@@ -2108,7 +2108,7 @@ Private Sub HandleUpdateDexterity()
     frmMain.lblDext.Caption = UserAgilidad
     frmMain.lblDext.ForeColor = getDexterityColor()
     IntervaloDopas = incomingData.ReadLong
-    TiempoDopas = (IntervaloDopas * 0.05) - 1
+    TiempoDopas = IntervaloDopas * 0.04
 End Sub
 
 ''


### PR DESCRIPTION
Estaba mal el cálculo. Asumía que el gameTimer del server corre a 50ms, cuando en realidad corre a 40. También saqué el (-1) para que cuente desde la cantidad de segundos original hasta 1.