### PR TITLE
Fix desbordamiento en Damage_NewSize

### DIFF
--- a/CODIGO/Motor/mDx8_Dibujado.bas
+++ b/CODIGO/Motor/mDx8_Dibujado.bas
@@ -290,7 +290,7 @@ Function Damage_ModifyColour(ByVal DamageType As Byte) As Long
  
 End Function
  
-Function Damage_NewSize(ByVal ElapsedTime As Byte) As Byte
+Function Damage_NewSize(ByVal ElapsedTime As Long) As Byte
  
     ' @ Se usa para el "efecto" del apu.
 


### PR DESCRIPTION
No sé por qué, pero la función pedía de parámetro un Byte, cuando debería ser Long