### PR TITLE
Cambio la carpeta para guardar videos a c:/videos por que no deja guardar los videos en la carpeta del juego por el UAC

### DIFF
--- a/CODIGO/Aplicacion/GameIni.bas
+++ b/CODIGO/Aplicacion/GameIni.bas
@@ -130,7 +130,16 @@ Public Function path(ByVal PathType As ePath) As String
             path = App.path & "\Extras\"
 
         Case ePath.Videos
-            path = App.path & "\Videos\"
+            'Hacemos un Left para poder solo obtener la letra del HD
+            'Por que por culpa del UAC no guarda los videos en la carpeta del juego...
+            Dim VideosPath As String
+            VideosPath = Left$(App.path, 2) & "\Videos\"
+
+            If Dir(VideosPath, vbDirectory) = "" Then
+                MkDir VideosPath
+            End If
+            
+            path = VideosPath
     
     End Select
 


### PR DESCRIPTION
Cambio la carpeta para guardar videos a c:/videos por que no deja guardar los videos en la carpeta del juego por el UAC